### PR TITLE
fix: correct nested API response access for image caption generation

### DIFF
--- a/src/Components/Artcaption/Artcaption.jsx
+++ b/src/Components/Artcaption/Artcaption.jsx
@@ -35,7 +35,7 @@ export default function Generate() {
             },
           }
         );
-        setdataAnalysis(data.data.data);
+        setdataAnalysis(data.data);
         console.log(data.data.data);
       } catch (error) {
         console.error("Error uploading image:", error);


### PR DESCRIPTION
Adjusted the response parsing from `data.data.data` to `data.data` to correctly access the `caption` field and avoid runtime TypeError in the Generate component